### PR TITLE
change cmd to entrypoint so args can be appended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:12-alpine
 
 COPY ./build/libs/spring-boot-payments-0.0.10.jar .
 
-CMD ["java", "-jar", "./spring-boot-payments-0.0.10.jar"]
+ENTRYPOINT ["java", "-jar", "./spring-boot-payments-0.0.10.jar"]


### PR DESCRIPTION
I change CMD to ENTRYPOINT in the Dockerfile so that the config files can be overridden by passing args in